### PR TITLE
Add link metadata previews to decoded audio messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+npm-debug.log*
+/dist
+/tmp

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # AudioLink
+
+AudioLink is a proof-of-concept web application that uses the [ggwave](https://github.com/ggerganov/ggwave) library to transmit short text messages over sound. The Node.js backend wraps the ggwave encoder/decoder while the frontend provides simple controls to generate audio, play it, record microphone input, and recover messages.
+
+## Features
+
+- Encode arbitrary text into an audible waveform using ggwave protocols.
+- Download or play the generated audio directly in the browser.
+- Decode messages by uploading the generated audio file or recording through the microphone.
+- Launch a dedicated "Scan Now" page to immediately listen for nearby sound payloads.
+- Preview decoded links with fetched metadata (title, description, image) when available.
+- Automatic protocol discovery from the ggwave module.
+
+## Prerequisites
+
+- Node.js 18+
+- npm
+
+## Getting started
+
+```bash
+npm install
+npm run start
+```
+
+The server listens on [http://localhost:3000](http://localhost:3000). Open the address in your browser to use the main UI, or navigate to
+[http://localhost:3000/scan.html](http://localhost:3000/scan.html) for the dedicated scanning experience.
+
+## Project structure
+
+```
+├── public/
+│   ├── app.js        # Main frontend logic (encoding, decoding, microphone recording)
+│   ├── index.html    # Primary UI layout
+│   ├── scan.css      # Landing page styling for sound scanning
+│   ├── scan.html     # Standalone scanning landing page
+│   └── scan.js       # Scan page microphone controls and decode wiring
+├── src/
+│   └── server.js     # Express server with ggwave bindings
+├── package.json
+└── README.md
+```
+
+## Notes
+
+- Decoding works best when the playback device and microphone are near each other and ambient noise is limited.
+- The backend resamples uploaded/recorded audio to ggwave's default sample rate (48 kHz) before decoding.
+- The demo is intended for local testing and is not hardened for production use.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1128 @@
+{
+  "name": "audiolink",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "audiolink",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio": "^1.0.0-rc.12",
+        "express": "^5.1.0",
+        "ggwave": "^0.4.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ggwave": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ggwave/-/ggwave-0.4.0.tgz",
+      "integrity": "sha512-+sKq0aIEVJ7zHj4Vw+Sj/RPa91xp76ihaG5gsOKZ8ojM5+uUu3NFzAspozwBx/zeaThxP5VeIkA2bbsfWpUd2g==",
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "audiolink",
+  "version": "1.0.0",
+  "description": "Proof of concept web app that encodes/decodes text over sound with ggwave.",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "cheerio": "^1.0.0-rc.12",
+    "express": "^5.1.0",
+    "ggwave": "^0.4.0"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,302 @@
+const protocolSelect = document.getElementById('protocol-select');
+const volumeRange = document.getElementById('volume-range');
+const volumeValue = document.getElementById('volume-value');
+const encodeForm = document.getElementById('encode-form');
+const encodeText = document.getElementById('encode-text');
+const encodeAudio = document.getElementById('encode-audio');
+const downloadLink = document.getElementById('download-link');
+const encodeOutput = document.getElementById('encode-output');
+const decodeFileInput = document.getElementById('decode-file');
+const decodeFileButton = document.getElementById('decode-file-button');
+const decodedText = document.getElementById('decoded-text');
+const recordToggle = document.getElementById('record-toggle');
+const status = document.getElementById('status');
+const linkPreview = document.getElementById('link-preview');
+const previewImage = document.getElementById('preview-image');
+const previewTitle = document.getElementById('preview-title');
+const previewDescription = document.getElementById('preview-description');
+const previewUrl = document.getElementById('preview-url');
+const previewSource = document.getElementById('preview-source');
+
+let mediaRecorder;
+let audioChunks = [];
+let audioContext;
+let currentDownloadUrl;
+
+function updateStatus(message, tone = 'info') {
+  status.textContent = message || '';
+  status.dataset.tone = tone;
+}
+
+function float32ToBase64(float32Array) {
+  const buffer = new ArrayBuffer(float32Array.length * Float32Array.BYTES_PER_ELEMENT);
+  const view = new Float32Array(buffer);
+  view.set(float32Array);
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function resetLinkPreview() {
+  linkPreview.hidden = true;
+  previewImage.hidden = true;
+  previewImage.removeAttribute('src');
+  previewTitle.textContent = '';
+  previewTitle.hidden = true;
+  previewDescription.textContent = '';
+  previewDescription.hidden = true;
+  previewSource.textContent = '';
+  previewSource.hidden = true;
+  previewUrl.textContent = '';
+  previewUrl.href = '#';
+  previewUrl.hidden = true;
+}
+
+function formatDisplayUrl(urlString) {
+  if (!urlString) {
+    return '';
+  }
+  try {
+    const url = new URL(urlString);
+    return url.hostname + url.pathname.replace(/\/$/, '');
+  } catch (error) {
+    return urlString;
+  }
+}
+
+function updateLinkPreview(metadata, fallbackUrl) {
+  if (!metadata) {
+    resetLinkPreview();
+    return;
+  }
+
+  const targetUrl = metadata.url || fallbackUrl;
+  const hasImage = Boolean(metadata.image);
+  const hasTitle = Boolean(metadata.title);
+  const hasDescription = Boolean(metadata.description);
+  const hasContent = hasImage || hasTitle || hasDescription;
+
+  if (!hasContent && !targetUrl) {
+    resetLinkPreview();
+    return;
+  }
+
+  if (hasImage) {
+    previewImage.src = metadata.image;
+    previewImage.hidden = false;
+  } else {
+    previewImage.removeAttribute('src');
+    previewImage.hidden = true;
+  }
+
+  if (hasTitle) {
+    previewTitle.textContent = metadata.title;
+    previewTitle.hidden = false;
+  } else {
+    previewTitle.textContent = '';
+    previewTitle.hidden = true;
+  }
+
+  if (hasDescription) {
+    previewDescription.textContent = metadata.description;
+    previewDescription.hidden = false;
+  } else {
+    previewDescription.textContent = '';
+    previewDescription.hidden = true;
+  }
+
+  if (targetUrl) {
+    previewUrl.href = targetUrl;
+    previewUrl.textContent = formatDisplayUrl(targetUrl) || targetUrl;
+    previewUrl.hidden = false;
+    previewSource.textContent = formatDisplayUrl(targetUrl);
+    previewSource.hidden = false;
+  } else {
+    previewUrl.href = '#';
+    previewUrl.textContent = '';
+    previewUrl.hidden = true;
+    previewSource.textContent = '';
+    previewSource.hidden = true;
+  }
+
+  linkPreview.hidden = false;
+}
+
+function downloadBlobUrl(base64, mimeType) {
+  const byteCharacters = atob(base64);
+  const byteNumbers = new Array(byteCharacters.length);
+  for (let i = 0; i < byteCharacters.length; i += 1) {
+    byteNumbers[i] = byteCharacters.charCodeAt(i);
+  }
+  const byteArray = new Uint8Array(byteNumbers);
+  const blob = new Blob([byteArray], { type: mimeType });
+  if (currentDownloadUrl) {
+    URL.revokeObjectURL(currentDownloadUrl);
+  }
+  currentDownloadUrl = URL.createObjectURL(blob);
+  return currentDownloadUrl;
+}
+
+async function populateProtocols() {
+  try {
+    const response = await fetch('/api/protocols');
+    const { protocols } = await response.json();
+    protocolSelect.innerHTML = '';
+    protocols.forEach(({ key }) => {
+      const option = document.createElement('option');
+      option.value = key;
+      option.textContent = key.replace('GGWAVE_PROTOCOL_', '').replace(/_/g, ' ');
+      if (key === 'GGWAVE_PROTOCOL_AUDIBLE_FAST') {
+        option.selected = true;
+      }
+      protocolSelect.appendChild(option);
+    });
+  } catch (error) {
+    console.error('Failed to load protocols', error);
+    updateStatus('Unable to load ggwave protocols.', 'error');
+  }
+}
+
+async function encodeMessage(event) {
+  event.preventDefault();
+  const text = encodeText.value.trim();
+  if (!text) {
+    updateStatus('Please enter a message before encoding.', 'warning');
+    return;
+  }
+
+  updateStatus('Generating audio payload…');
+
+  try {
+    const response = await fetch('/api/encode', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text,
+        protocol: protocolSelect.value,
+        volume: Number(volumeRange.value),
+      }),
+    });
+
+    if (!response.ok) {
+      const { error } = await response.json();
+      throw new Error(error || 'Failed to encode message.');
+    }
+
+    const result = await response.json();
+    const { audioBase64, mimeType } = result;
+    const objectUrl = downloadBlobUrl(audioBase64, mimeType);
+
+    encodeAudio.src = `data:${mimeType};base64,${audioBase64}`;
+    encodeAudio.load();
+    downloadLink.href = objectUrl;
+    encodeOutput.hidden = false;
+    updateStatus('Audio ready. Play it or hold it near your microphone to decode.');
+  } catch (error) {
+    console.error(error);
+    updateStatus(error.message || 'Encoding failed.', 'error');
+  }
+}
+
+async function decodeFloat32(float32Array, sampleRate) {
+  const base64 = float32ToBase64(float32Array);
+  const response = await fetch('/api/decode', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ audioBase64: base64, sampleRate }),
+  });
+
+  if (!response.ok) {
+    const { error } = await response.json();
+    throw new Error(error || 'Decoding failed.');
+  }
+
+  const data = await response.json();
+  if (!data.success) {
+    updateStatus(data.message || 'No payload detected.', 'warning');
+    resetLinkPreview();
+  } else {
+    updateStatus('Successfully decoded message!');
+    updateLinkPreview(data.metadata, data.text);
+  }
+  decodedText.textContent = data.text || '';
+}
+
+async function decodeUploadedFile() {
+  const file = decodeFileInput.files?.[0];
+  if (!file) {
+    updateStatus('Please choose an audio file to decode.', 'warning');
+    return;
+  }
+
+  updateStatus('Processing audio file…');
+
+  try {
+    if (!audioContext) {
+      audioContext = new AudioContext();
+    }
+    const arrayBuffer = await file.arrayBuffer();
+    const decoded = await audioContext.decodeAudioData(arrayBuffer.slice(0));
+    const channelData = decoded.getChannelData(0);
+    await decodeFloat32(channelData, decoded.sampleRate);
+  } catch (error) {
+    console.error(error);
+    updateStatus(error.message || 'Unable to decode file.', 'error');
+  }
+}
+
+async function handleRecordingToggle() {
+  if (mediaRecorder && mediaRecorder.state === 'recording') {
+    mediaRecorder.stop();
+    recordToggle.textContent = 'Start recording';
+    updateStatus('Processing recording…');
+    return;
+  }
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    audioChunks = [];
+    mediaRecorder = new MediaRecorder(stream);
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data.size > 0) {
+        audioChunks.push(event.data);
+      }
+    };
+    mediaRecorder.onstop = async () => {
+      try {
+        const blob = new Blob(audioChunks, { type: mediaRecorder.mimeType });
+        mediaRecorder.stream.getTracks().forEach((track) => track.stop());
+        if (!audioContext) {
+          audioContext = new AudioContext();
+        }
+        const arrayBuffer = await blob.arrayBuffer();
+        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+        const channelData = audioBuffer.getChannelData(0);
+        await decodeFloat32(channelData, audioBuffer.sampleRate);
+        updateStatus('Recording decoded.');
+      } catch (error) {
+        console.error(error);
+        updateStatus(error.message || 'Unable to process recording.', 'error');
+      }
+    };
+    mediaRecorder.start();
+    recordToggle.textContent = 'Stop recording';
+    updateStatus('Recording… play the encoded sound now.');
+  } catch (error) {
+    console.error(error);
+    updateStatus('Microphone access denied.', 'error');
+  }
+}
+
+volumeRange.addEventListener('input', () => {
+  volumeValue.textContent = volumeRange.value;
+});
+
+encodeForm.addEventListener('submit', encodeMessage);
+decodeFileButton.addEventListener('click', decodeUploadedFile);
+recordToggle.addEventListener('click', handleRecordingToggle);
+
+populateProtocols();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AudioLink – ggwave POC</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>AudioLink</h1>
+        <p class="tagline">Proof of concept using ggwave to send text over sound.</p>
+      </header>
+
+      <section class="card" id="encode-section">
+        <h2>Encode text</h2>
+        <form id="encode-form">
+          <label for="encode-text">Message</label>
+          <textarea id="encode-text" rows="3" placeholder="Type a short message"></textarea>
+
+          <div class="row">
+            <label for="protocol-select">Protocol</label>
+            <select id="protocol-select"></select>
+          </div>
+
+          <div class="row">
+            <label for="volume-range">Volume</label>
+            <input type="range" id="volume-range" min="1" max="50" value="10" />
+            <span id="volume-value">10</span>
+          </div>
+
+          <button type="submit">Generate audio</button>
+        </form>
+        <div class="output" id="encode-output" hidden>
+          <audio id="encode-audio" controls></audio>
+          <a id="download-link" download="message.wav">Download WAV</a>
+        </div>
+      </section>
+
+      <section class="card" id="decode-section">
+        <h2>Decode audio</h2>
+        <div class="decode-options">
+          <div class="decode-upload">
+            <label for="decode-file">Upload WAV</label>
+            <input id="decode-file" type="file" accept="audio/wav,audio/*" />
+            <button id="decode-file-button">Decode uploaded audio</button>
+          </div>
+          <div class="decode-record">
+            <button id="record-toggle">Start recording</button>
+            <p class="hint">Play the generated sound near your microphone to test decoding.</p>
+          </div>
+        </div>
+        <div class="output" id="decode-output">
+          <p id="decoded-text" class="decoded-text"></p>
+          <div id="link-preview" class="link-preview" hidden>
+            <div class="link-preview__media">
+              <img id="preview-image" alt="Link preview image" hidden />
+            </div>
+            <div class="link-preview__content">
+              <p class="link-preview__source" id="preview-source"></p>
+              <h3 class="link-preview__title" id="preview-title"></h3>
+              <p class="link-preview__description" id="preview-description"></p>
+              <a
+                id="preview-url"
+                class="link-preview__url"
+                href="#"
+                target="_blank"
+                rel="noopener noreferrer"
+              ></a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="card info">
+        <h2>How it works</h2>
+        <p>
+          Text is converted to an audio waveform on the server using the
+          <strong>ggwave</strong> library. The generated sound can be played or downloaded.
+          You can record or upload that sound and the server will attempt to recover the original text.
+        </p>
+      </section>
+
+      <div id="status" role="status" aria-live="polite"></div>
+    </main>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/public/scan.css
+++ b/public/scan.css
@@ -1,0 +1,286 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
+
+:root {
+  color-scheme: light;
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  --bg: #060715;
+  --text: rgba(255, 255, 255, 0.86);
+  --muted: rgba(255, 255, 255, 0.6);
+  --accent-start: #6d7dfc;
+  --accent-end: #78e8f7;
+  --accent: #7de1ff;
+  --glass: rgba(255, 255, 255, 0.06);
+  --border: rgba(255, 255, 255, 0.15);
+  --danger: #ff6b81;
+  --success: #3ef3b0;
+  --warning: #f5d676;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, rgba(109, 125, 252, 0.25), transparent 55%),
+    radial-gradient(circle at bottom, rgba(120, 232, 247, 0.2), transparent 50%), var(--bg);
+  color: var(--text);
+  padding: 2rem;
+}
+
+.background {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="1440" height="700" viewBox="0 0 1440 700" fill="none"%3E%3Cpath d="M0 350C80 310 160 310 240 350C320 390 400 390 480 350C560 310 640 310 720 350C800 390 880 390 960 350C1040 310 1120 310 1200 350C1280 390 1360 390 1440 350" stroke="url(%23paint0_linear_0_1)" stroke-width="2" stroke-linecap="round"/%3E%3Cdefs%3E%3ClinearGradient id="paint0_linear_0_1" x1="0" y1="350" x2="1440" y2="350" gradientUnits="userSpaceOnUse"%3E%3Cstop stop-color="%236D7DFC"/%3E%3Cstop offset="1" stop-color="%2378E8F7"/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E') center/cover no-repeat;
+  opacity: 0.5;
+  filter: blur(0.5px);
+}
+
+.hero {
+  position: relative;
+  max-width: 720px;
+  width: min(100%, 720px);
+  padding: 3.5rem clamp(2rem, 4vw, 3.5rem);
+  border-radius: 28px;
+  background: linear-gradient(145deg, rgba(18, 20, 52, 0.85), rgba(17, 21, 46, 0.65));
+  border: 1px solid var(--border);
+  box-shadow: 0 40px 80px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(22px);
+  text-align: center;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-bottom: 1rem;
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
+  font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+
+.hero__accent {
+  background: linear-gradient(120deg, var(--accent-start), var(--accent-end));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.hero__subtitle {
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: var(--muted);
+  margin-bottom: 2rem;
+}
+
+.hero__features {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem 1.5rem;
+  list-style: none;
+  margin-bottom: 2.5rem;
+}
+
+.hero__features li {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(125, 225, 255, 0.12);
+  border: 1px solid rgba(125, 225, 255, 0.2);
+  font-size: 0.9rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+
+.cta {
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.9rem 2.6rem;
+  border-radius: 999px;
+  border: none;
+  color: #080b17;
+  background: linear-gradient(120deg, var(--accent-start), var(--accent-end));
+  box-shadow: 0 18px 38px rgba(109, 125, 252, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 26px 45px rgba(109, 125, 252, 0.45);
+}
+
+.cta:active {
+  transform: translateY(1px);
+}
+
+.cta--secondary {
+  color: var(--text);
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: none;
+}
+
+.hero__footnote {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-bottom: 2rem;
+}
+
+.scanner {
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: rgba(8, 11, 23, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: grid;
+  gap: 1rem;
+}
+
+.scanner__status {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.scanner__status[data-tone='active'] {
+  color: var(--accent);
+}
+
+.scanner__status[data-tone='success'] {
+  color: var(--success);
+}
+
+.scanner__status[data-tone='error'] {
+  color: var(--danger);
+}
+
+.scanner__status[data-tone='warning'] {
+  color: var(--warning);
+}
+
+.scanner__result {
+  padding: 1.25rem;
+  background: rgba(125, 225, 255, 0.08);
+  border-radius: 16px;
+  border: 1px solid rgba(125, 225, 255, 0.22);
+  text-align: left;
+}
+
+.scanner__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 0.6rem;
+}
+
+.scanner__message {
+  font-size: 1.25rem;
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.scanner__preview {
+  margin-top: 1.25rem;
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 1rem;
+  background: rgba(8, 11, 23, 0.6);
+  border-radius: 18px;
+  border: 1px solid rgba(125, 225, 255, 0.25);
+  padding: 1rem;
+}
+
+.scanner__preview-media {
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(125, 225, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scanner__preview-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.scanner__preview-content {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.scanner__preview-source {
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.scanner__preview-title {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--text);
+}
+
+.scanner__preview-description {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.95rem;
+}
+
+.scanner__preview-url {
+  color: var(--accent);
+  font-weight: 600;
+  word-break: break-all;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1.25rem;
+  }
+
+  .hero {
+    padding: 2.5rem 1.75rem;
+  }
+
+  .hero__features {
+    gap: 0.6rem 1rem;
+  }
+
+  .cta {
+    width: 100%;
+  }
+
+  .scanner__preview {
+    grid-template-columns: 1fr;
+  }
+
+  .scanner__preview-media {
+    max-height: 220px;
+  }
+}

--- a/public/scan.html
+++ b/public/scan.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AudioLink Scanner</title>
+    <link rel="stylesheet" href="scan.css" />
+  </head>
+  <body>
+    <div class="background" aria-hidden="true"></div>
+    <main class="hero">
+      <header class="hero__header">
+        <p class="eyebrow">AudioLink Demo</p>
+        <h1 class="hero__title">
+          Scan the air for <span class="hero__accent">sound links</span>
+        </h1>
+        <p class="hero__subtitle">
+          Convert any digital link into sound and decode it back using only your
+          microphone. The futuristic alternative to QR codes, right in your
+          browser.
+        </p>
+      </header>
+      <ul class="hero__features">
+        <li>Audio Detection</li>
+        <li>Sound Generation</li>
+        <li>Instant Conversion</li>
+        <li>Universal Links</li>
+      </ul>
+      <div class="hero__actions">
+        <button id="scan-toggle" class="cta" aria-pressed="false">Scan Now</button>
+        <a href="/" class="cta cta--secondary">Generate Sound</a>
+      </div>
+      <p class="hero__footnote">Try the demo · No signup required · Works on any device</p>
+      <section class="scanner" aria-live="polite">
+        <p id="status" class="scanner__status" data-tone="muted">
+          Ready to listen for ggwave messages.
+        </p>
+        <div id="result" class="scanner__result" hidden>
+          <p class="scanner__label">Last decoded message</p>
+          <p id="result-text" class="scanner__message"></p>
+          <div id="result-preview" class="scanner__preview" hidden>
+            <div class="scanner__preview-media">
+              <img id="result-preview-image" alt="Link preview image" hidden />
+            </div>
+            <div class="scanner__preview-content">
+              <p class="scanner__preview-source" id="result-preview-source"></p>
+              <h3 class="scanner__preview-title" id="result-preview-title"></h3>
+              <p class="scanner__preview-description" id="result-preview-description"></p>
+              <a
+                id="result-preview-link"
+                class="scanner__preview-url"
+                href="#"
+                target="_blank"
+                rel="noopener noreferrer"
+              ></a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <script src="scan.js" type="module"></script>
+  </body>
+</html>

--- a/public/scan.js
+++ b/public/scan.js
@@ -1,0 +1,220 @@
+const scanToggle = document.getElementById('scan-toggle');
+const status = document.getElementById('status');
+const result = document.getElementById('result');
+const resultText = document.getElementById('result-text');
+const resultPreview = document.getElementById('result-preview');
+const resultPreviewImage = document.getElementById('result-preview-image');
+const resultPreviewTitle = document.getElementById('result-preview-title');
+const resultPreviewDescription = document.getElementById('result-preview-description');
+const resultPreviewLink = document.getElementById('result-preview-link');
+const resultPreviewSource = document.getElementById('result-preview-source');
+
+let mediaRecorder;
+let audioChunks = [];
+let audioContext;
+let isScanning = false;
+
+function setStatus(message, tone = 'muted') {
+  status.textContent = message;
+  status.dataset.tone = tone;
+}
+
+function float32ToBase64(float32Array) {
+  const buffer = new ArrayBuffer(float32Array.length * Float32Array.BYTES_PER_ELEMENT);
+  const view = new Float32Array(buffer);
+  view.set(float32Array);
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function resetPreview() {
+  resultPreview.hidden = true;
+  resultPreviewImage.hidden = true;
+  resultPreviewImage.removeAttribute('src');
+  resultPreviewTitle.textContent = '';
+  resultPreviewTitle.hidden = true;
+  resultPreviewDescription.textContent = '';
+  resultPreviewDescription.hidden = true;
+  resultPreviewLink.textContent = '';
+  resultPreviewLink.href = '#';
+  resultPreviewLink.hidden = true;
+  resultPreviewSource.textContent = '';
+  resultPreviewSource.hidden = true;
+}
+
+function formatDisplayUrl(urlString) {
+  if (!urlString) {
+    return '';
+  }
+  try {
+    const url = new URL(urlString);
+    return url.hostname + url.pathname.replace(/\/$/, '');
+  } catch (error) {
+    return urlString;
+  }
+}
+
+function updatePreview(metadata, fallbackUrl) {
+  if (!metadata) {
+    resetPreview();
+    return;
+  }
+
+  const targetUrl = metadata.url || fallbackUrl;
+  const hasImage = Boolean(metadata.image);
+  const hasTitle = Boolean(metadata.title);
+  const hasDescription = Boolean(metadata.description);
+  const hasContent = hasImage || hasTitle || hasDescription;
+
+  if (!hasContent && !targetUrl) {
+    resetPreview();
+    return;
+  }
+
+  if (hasImage) {
+    resultPreviewImage.src = metadata.image;
+    resultPreviewImage.hidden = false;
+  } else {
+    resultPreviewImage.removeAttribute('src');
+    resultPreviewImage.hidden = true;
+  }
+
+  if (hasTitle) {
+    resultPreviewTitle.textContent = metadata.title;
+    resultPreviewTitle.hidden = false;
+  } else {
+    resultPreviewTitle.textContent = '';
+    resultPreviewTitle.hidden = true;
+  }
+
+  if (hasDescription) {
+    resultPreviewDescription.textContent = metadata.description;
+    resultPreviewDescription.hidden = false;
+  } else {
+    resultPreviewDescription.textContent = '';
+    resultPreviewDescription.hidden = true;
+  }
+
+  if (targetUrl) {
+    const displayUrl = formatDisplayUrl(targetUrl) || targetUrl;
+    resultPreviewLink.href = targetUrl;
+    resultPreviewLink.textContent = displayUrl;
+    resultPreviewLink.hidden = false;
+    resultPreviewSource.textContent = displayUrl;
+    resultPreviewSource.hidden = false;
+  } else {
+    resultPreviewLink.href = '#';
+    resultPreviewLink.textContent = '';
+    resultPreviewLink.hidden = true;
+    resultPreviewSource.textContent = '';
+    resultPreviewSource.hidden = true;
+  }
+
+  resultPreview.hidden = false;
+}
+
+async function decodeFloat32(float32Array, sampleRate) {
+  const base64 = float32ToBase64(float32Array);
+  const response = await fetch('/api/decode', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ audioBase64: base64, sampleRate }),
+  });
+
+  if (!response.ok) {
+    const { error } = await response.json();
+    throw new Error(error || 'Decoding failed.');
+  }
+
+  const payload = await response.json();
+  if (payload.success) {
+    result.hidden = false;
+    resultText.textContent = payload.text || '';
+    updatePreview(payload.metadata, payload.text);
+    setStatus('Message detected! Check the decoded text below.', 'success');
+  } else {
+    result.hidden = true;
+    resultText.textContent = '';
+    resetPreview();
+    setStatus(payload.message || 'No payload detected.', 'warning');
+  }
+}
+
+async function stopScanning() {
+  if (!mediaRecorder) {
+    return;
+  }
+  mediaRecorder.stop();
+  setStatus('Processing recording…');
+  scanToggle.textContent = 'Scan Now';
+  scanToggle.dataset.state = 'idle';
+  scanToggle.setAttribute('aria-pressed', 'false');
+  isScanning = false;
+}
+
+async function startScanning() {
+  try {
+    if (!audioContext) {
+      audioContext = new AudioContext();
+    }
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    audioChunks = [];
+    mediaRecorder = new MediaRecorder(stream);
+
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data.size > 0) {
+        audioChunks.push(event.data);
+      }
+    };
+
+    mediaRecorder.onstop = async () => {
+      try {
+        const blob = new Blob(audioChunks, { type: mediaRecorder.mimeType });
+        mediaRecorder.stream.getTracks().forEach((track) => track.stop());
+        const arrayBuffer = await blob.arrayBuffer();
+        const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+        const channelData = audioBuffer.getChannelData(0);
+        await decodeFloat32(channelData, audioBuffer.sampleRate);
+      } catch (error) {
+        console.error('Unable to process recording', error);
+        setStatus(error.message || 'Unable to process recording.', 'error');
+      } finally {
+        mediaRecorder = null;
+        audioChunks = [];
+      }
+    };
+
+    mediaRecorder.start();
+    setStatus('Listening… hold the speaker close to your microphone.', 'active');
+    scanToggle.textContent = 'Stop Listening';
+    scanToggle.dataset.state = 'recording';
+    scanToggle.setAttribute('aria-pressed', 'true');
+    isScanning = true;
+  } catch (error) {
+    console.error('Microphone access denied', error);
+    setStatus('Microphone access denied. Please enable audio permissions.', 'error');
+    scanToggle.textContent = 'Scan Now';
+    scanToggle.dataset.state = 'idle';
+    scanToggle.setAttribute('aria-pressed', 'false');
+    isScanning = false;
+  }
+}
+
+scanToggle.addEventListener('click', async () => {
+  if (isScanning && mediaRecorder?.state === 'recording') {
+    await stopScanning();
+  } else if (!isScanning) {
+    await startScanning();
+  }
+});
+
+window.addEventListener('keydown', (event) => {
+  if (event.code === 'Space' && !event.repeat) {
+    event.preventDefault();
+    scanToggle.click();
+  }
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,258 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+  background: radial-gradient(circle at top, #4f46e5, #1e1b4b 45%, #09090b 80%);
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  color: #f8fafc;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 0.25rem;
+}
+
+.tagline {
+  margin: 0;
+  color: #e0e7ff;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(8px);
+}
+
+.card h2 {
+  margin-top: 0;
+  color: #c7d2fe;
+}
+
+label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 4rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.75rem;
+  font-size: 1rem;
+  background: rgba(15, 23, 42, 0.85);
+  color: inherit;
+}
+
+textarea:focus,
+select:focus,
+input:focus,
+button:focus {
+  outline: 2px solid rgba(99, 102, 241, 0.9);
+  outline-offset: 2px;
+}
+
+select,
+input[type='file'],
+input[type='range'] {
+  width: 100%;
+  margin-bottom: 0.75rem;
+}
+
+input[type='range'] {
+  accent-color: #6366f1;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.row label {
+  flex: 0 0 120px;
+}
+
+.row select,
+.row input[type='range'] {
+  flex: 1;
+}
+
+button {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(99, 102, 241, 0.35);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.output {
+  margin-top: 1rem;
+}
+
+#encode-audio {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+#download-link {
+  display: inline-block;
+  color: #a855f7;
+}
+
+.decoded-text {
+  font-size: 1.1rem;
+  font-weight: 600;
+  min-height: 1.5rem;
+  word-break: break-word;
+}
+
+.hint {
+  color: #cbd5f5;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.info {
+  font-size: 0.95rem;
+  color: #e2e8f0;
+}
+
+#status {
+  margin-top: 1rem;
+  text-align: center;
+  font-weight: 500;
+  color: #facc15;
+}
+
+@media (max-width: 720px) {
+  .row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .row label {
+    flex: none;
+  }
+
+  .decode-options {
+    display: grid;
+    gap: 1rem;
+  }
+}
+
+#status[data-tone='error'] {
+  color: #f87171;
+}
+
+#status[data-tone='warning'] {
+  color: #facc15;
+}
+
+#status[data-tone='info'] {
+  color: #38bdf8;
+}
+
+.link-preview {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 16px;
+  padding: 1rem;
+}
+
+.link-preview__media {
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(30, 41, 59, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.link-preview__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.link-preview__content {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.link-preview__source {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(203, 213, 225, 0.75);
+}
+
+.link-preview__title {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #f8fafc;
+}
+
+.link-preview__description {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.95rem;
+}
+
+.link-preview__url {
+  color: #a855f7;
+  font-weight: 600;
+  word-break: break-all;
+}
+
+@media (max-width: 640px) {
+  .link-preview {
+    grid-template-columns: 1fr;
+  }
+
+  .link-preview__media {
+    max-height: 200px;
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,308 @@
+const express = require('express');
+const path = require('path');
+const cheerio = require('cheerio');
+const ggwaveFactory = require('ggwave');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json({ limit: '10mb' }));
+app.use(express.static(path.join(__dirname, '../public')));
+
+let ggwaveModule;
+let ggwaveInstance;
+let defaultParameters;
+const METADATA_TIMEOUT_MS = 5000;
+
+async function ensureGgWave() {
+  if (ggwaveModule && ggwaveInstance) {
+    return { ggwave: ggwaveModule, instance: ggwaveInstance };
+  }
+
+  ggwaveModule = await ggwaveFactory();
+  defaultParameters = ggwaveModule.getDefaultParameters();
+  ggwaveInstance = ggwaveModule.init(defaultParameters);
+  if (typeof ggwaveModule.disableLog === 'function') {
+    ggwaveModule.disableLog();
+  }
+  return { ggwave: ggwaveModule, instance: ggwaveInstance };
+}
+
+function getProtocolId(ggwave, protocolName) {
+  if (!protocolName) {
+    return ggwave.ProtocolId.GGWAVE_PROTOCOL_AUDIBLE_FAST.value;
+  }
+  const protocol = ggwave.ProtocolId[protocolName];
+  if (!protocol) {
+    return null;
+  }
+  return protocol.value;
+}
+
+function float32ToWav(float32Array, sampleRate) {
+  const buffer = new ArrayBuffer(44 + float32Array.length * 2);
+  const view = new DataView(buffer);
+
+  function writeString(offset, string) {
+    for (let i = 0; i < string.length; i += 1) {
+      view.setUint8(offset + i, string.charCodeAt(i));
+    }
+  }
+
+  const numChannels = 1;
+  const bytesPerSample = 2;
+  const blockAlign = numChannels * bytesPerSample;
+  const byteRate = sampleRate * blockAlign;
+
+  writeString(0, 'RIFF');
+  view.setUint32(4, 36 + float32Array.length * bytesPerSample, true);
+  writeString(8, 'WAVE');
+  writeString(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true); // PCM
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bytesPerSample * 8, true);
+  writeString(36, 'data');
+  view.setUint32(40, float32Array.length * bytesPerSample, true);
+
+  const offset = 44;
+  const bufferView = new DataView(buffer, offset);
+  for (let i = 0; i < float32Array.length; i += 1) {
+    let sample = Math.max(-1, Math.min(1, float32Array[i]));
+    sample = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+    bufferView.setInt16(i * 2, sample, true);
+  }
+
+  return Buffer.from(buffer);
+}
+
+function resample(float32Array, fromSampleRate, toSampleRate) {
+  if (!float32Array || fromSampleRate === toSampleRate) {
+    return float32Array;
+  }
+  const ratio = fromSampleRate / toSampleRate;
+  const newLength = Math.round(float32Array.length / ratio);
+  const result = new Float32Array(newLength);
+  for (let i = 0; i < newLength; i += 1) {
+    const sourceIndex = i * ratio;
+    const lower = Math.floor(sourceIndex);
+    const upper = Math.min(lower + 1, float32Array.length - 1);
+    const weight = sourceIndex - lower;
+    result[i] = (1 - weight) * float32Array[lower] + weight * float32Array[upper];
+  }
+  return result;
+}
+
+function isHttpUrl(value) {
+  if (!value || typeof value !== 'string') {
+    return false;
+  }
+  try {
+    const parsed = new URL(value.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch (error) {
+    return false;
+  }
+}
+
+async function fetchLinkMetadata(urlString) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), METADATA_TIMEOUT_MS);
+  try {
+    const response = await fetch(urlString, {
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: {
+        'user-agent': 'AudioLink/1.0 (+https://github.com/ggerganov/ggwave)',
+        accept: 'text/html,application/xhtml+xml',
+      },
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('text/html')) {
+      return null;
+    }
+
+    const html = await response.text();
+    const $ = cheerio.load(html);
+
+    const getMeta = (selectors) => {
+      for (const selector of selectors) {
+        const value = $(selector).attr('content');
+        if (value) {
+          return value.trim();
+        }
+      }
+      return undefined;
+    };
+
+    const getText = (selector) => {
+      const value = $(selector).first().text();
+      return value ? value.trim() : undefined;
+    };
+
+    const title =
+      getMeta(["meta[property='og:title']", "meta[name='twitter:title']", "meta[name='title']"]) ||
+      getText('title');
+    const description =
+      getMeta([
+        "meta[property='og:description']",
+        "meta[name='description']",
+        "meta[name='twitter:description']",
+      ]);
+    const image = getMeta([
+      "meta[property='og:image']",
+      "meta[name='twitter:image']",
+      "meta[property='og:image:url']",
+    ]);
+
+    const metadata = {
+      url: response.url || urlString,
+    };
+
+    if (title) {
+      metadata.title = title;
+    }
+    if (description) {
+      metadata.description = description;
+    }
+    if (image) {
+      metadata.image = image;
+    }
+
+    if (!metadata.title && !metadata.description && !metadata.image) {
+      return metadata;
+    }
+
+    return metadata;
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      console.warn(`Metadata fetch timed out for ${urlString}`);
+    } else {
+      console.warn(`Unable to fetch metadata for ${urlString}:`, error.message);
+    }
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+app.post('/api/encode', async (req, res) => {
+  try {
+    const { ggwave } = await ensureGgWave();
+    const { text, protocol, volume = 10 } = req.body || {};
+
+    if (!text || typeof text !== 'string') {
+      return res.status(400).json({ error: 'A text payload is required.' });
+    }
+
+    const protocolId = getProtocolId(ggwave, protocol);
+    if (protocol && protocolId === null) {
+      return res.status(400).json({ error: `Unknown protocol: ${protocol}` });
+    }
+
+    const waveformBytes = ggwave.encode(
+      ggwaveInstance,
+      text,
+      protocolId,
+      Number(volume) || 10,
+    );
+
+    const float32Array = new Float32Array(
+      waveformBytes.buffer,
+      waveformBytes.byteOffset,
+      waveformBytes.length / Float32Array.BYTES_PER_ELEMENT,
+    );
+
+    const wavBuffer = float32ToWav(float32Array, defaultParameters.sampleRate);
+    const base64 = wavBuffer.toString('base64');
+
+    return res.json({
+      audioBase64: base64,
+      mimeType: 'audio/wav',
+      sampleRate: defaultParameters.sampleRate,
+      protocol: protocol || 'GGWAVE_PROTOCOL_AUDIBLE_FAST',
+    });
+  } catch (error) {
+    console.error('Failed to encode text:', error);
+    return res.status(500).json({ error: 'Encoding failed.' });
+  }
+});
+
+app.post('/api/decode', async (req, res) => {
+  try {
+    const { ggwave } = await ensureGgWave();
+    const { audioBase64, sampleRate } = req.body || {};
+
+    if (!audioBase64) {
+      return res.status(400).json({ error: 'Audio data is required.' });
+    }
+
+    const audioBuffer = Buffer.from(audioBase64, 'base64');
+    const arrayBuffer = audioBuffer.buffer.slice(
+      audioBuffer.byteOffset,
+      audioBuffer.byteOffset + audioBuffer.byteLength,
+    );
+    let float32Array = new Float32Array(arrayBuffer);
+
+    const incomingSampleRate = Number(sampleRate) || defaultParameters.sampleRate;
+    if (incomingSampleRate !== defaultParameters.sampleRate) {
+      float32Array = resample(float32Array, incomingSampleRate, defaultParameters.sampleRate);
+    }
+
+    const byteArray = new Int8Array(
+      float32Array.buffer,
+      float32Array.byteOffset,
+      float32Array.byteLength,
+    );
+
+    const decoded = ggwave.decode(ggwaveInstance, byteArray);
+
+    if (!decoded || decoded.length === 0) {
+      return res.status(200).json({ text: '', success: false, message: 'No payload detected.' });
+    }
+
+    const text = Buffer.from(decoded).toString('utf-8');
+    let metadata = null;
+
+    if (isHttpUrl(text)) {
+      metadata = await fetchLinkMetadata(text);
+    }
+
+    return res.json({ text, success: true, metadata });
+  } catch (error) {
+    console.error('Failed to decode audio:', error);
+    return res.status(500).json({ error: 'Decoding failed.' });
+  }
+});
+
+app.get('/api/protocols', async (_req, res) => {
+  try {
+    const { ggwave } = await ensureGgWave();
+    const entries = Object.entries(ggwave.ProtocolId)
+      .filter(([, value]) => typeof value === 'object' && 'value' in value)
+      .map(([key, value]) => ({ key, value: value.value }));
+    res.json({ protocols: entries });
+  } catch (error) {
+    console.error('Failed to load protocols:', error);
+    res.status(500).json({ error: 'Unable to list protocols.' });
+  }
+});
+
+ensureGgWave()
+  .then(() => {
+    app.listen(PORT, () => {
+      console.log(`Server listening on http://localhost:${PORT}`);
+    });
+  })
+  .catch((error) => {
+    console.error('Failed to initialize ggwave:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- fetch open graph style metadata for decoded URLs on the server and include it in decode responses
- render rich link previews on the main encoder/decoder page and the scan landing page when metadata is available
- document the new link preview behavior and add cheerio as a dependency for HTML parsing

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d9348279e88323b4d7f0910d0e9f91